### PR TITLE
Fix Keycloak Mixed Content Warnings

### DIFF
--- a/iac/infrastructure/constructs/ecs_services.py
+++ b/iac/infrastructure/constructs/ecs_services.py
@@ -122,7 +122,10 @@ class EcsServicesConstruct(Construct):
                     {"name": "KC_HOSTNAME_STRICT_HTTPS", "value": "true"},
                     {"name": "KC_HOSTNAME", "value": host_name},
                     {"name": "KC_HOSTNAME_URL", "value": f"https://{host_name}/auth"},
-                    {"name": "KC_HOSTNAME_ADMIN_URL", "value": f"https://{host_name}/auth"},
+                    {
+                        "name": "KC_HOSTNAME_ADMIN_URL",
+                        "value": f"https://{host_name}/auth",
+                    },
                     {"name": "KC_HTTP_RELATIVE_PATH", "value": "/auth"},
                     {"name": "PROXY_ADDRESS_FORWARDING", "value": "true"},
                     {"name": "KC_HTTP_MAX_FORWARDED_HEADER_SIZE", "value": "50"},

--- a/iac/infrastructure/constructs/ecs_services.py
+++ b/iac/infrastructure/constructs/ecs_services.py
@@ -24,7 +24,7 @@ class EcsServicesConstruct(Construct):
     Parameters:
         scope (Construct): The scope in which this construct is defined.
         id (str): The unique identifier of the construct.
-        alb_dns_name (str): The DNS name of the Application Load Balancer for routing traffic.
+        host_name (str): The custom domain name for the application.
         project_prefix (str): A prefix for project-related resource names to ensure uniqueness.
         environment (str): The environment name (e.g., `production`, `staging`) to differentiate resources.
         cluster_id (str): The ECS cluster identifier where services will be deployed.
@@ -53,7 +53,7 @@ class EcsServicesConstruct(Construct):
         scope: Construct,
         id: str,
         *,
-        alb_dns_name: str,
+        host_name: str,
         project_prefix: str,
         environment: str,
         cluster_id: str,
@@ -89,7 +89,7 @@ class EcsServicesConstruct(Construct):
                     {"containerPort": 9000, "hostPort": 9000, "protocol": "tcp"},
                 ],
                 "entryPoint": ["/opt/keycloak/bin/kc.sh"],
-                "command": ["start"],
+                "command": ["start", "--proxy-headers=xforwarded"],
                 "secrets": [
                     {
                         "name": "KC_DB_USERNAME",
@@ -119,14 +119,19 @@ class EcsServicesConstruct(Construct):
                     {"name": "KC_HTTP_ENABLED", "value": "true"},
                     {"name": "KC_PROXY", "value": "edge"},
                     {"name": "KC_HOSTNAME_STRICT", "value": "false"},
-                    {"name": "KC_HOSTNAME_STRICT_HTTPS", "value": "false"},
+                    {"name": "KC_HOSTNAME_STRICT_HTTPS", "value": "true"},
+                    {"name": "KC_HOSTNAME", "value": host_name},
+                    {"name": "KC_HOSTNAME_URL", "value": f"https://{host_name}/auth"},
+                    {"name": "KC_HOSTNAME_ADMIN_URL", "value": f"https://{host_name}/auth"},
+                    {"name": "KC_HTTP_RELATIVE_PATH", "value": "/auth"},
+                    {"name": "PROXY_ADDRESS_FORWARDING", "value": "true"},
+                    {"name": "KC_HTTP_MAX_FORWARDED_HEADER_SIZE", "value": "50"},
+                    {"name": "KC_HTTP_FORWARD_ROLES", "value": "true"},
+                    {"name": "KC_HTTPS_PROTOCOLS", "value": "TLSv1.2,TLSv1.3"},
                     {
                         "name": "JAVA_OPTS_APPEND",
                         "value": "-XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage=50",
                     },
-                    {"name": "KC_HTTP_RELATIVE_PATH", "value": "/auth"},
-                    {"name": "KC_HOSTNAME_STRICT", "value": "false"},
-                    {"name": "KC_HOSTNAME_STRICT_HTTPS", "value": "false"},
                 ],
                 "logConfiguration": {
                     "logDriver": "awslogs",
@@ -196,7 +201,7 @@ class EcsServicesConstruct(Construct):
                 "essential": True,
                 "portMappings": [{"containerPort": 8501, "protocol": "tcp"}],
                 "environment": [
-                    {"name": "KEYCLOAK_URL", "value": f"{alb_dns_name}/auth"},
+                    {"name": "KEYCLOAK_URL", "value": f"https://{host_name}/auth"},
                     {"name": "STREAMLIT_SERVER_PORT", "value": "8501"},
                     {"name": "STREAMLIT_SERVER_ADDRESS", "value": "0.0.0.0"},
                     {"name": "STREAMLIT_BROWSER_GATHER_USAGE_STATS", "value": "false"},

--- a/iac/infrastructure/stacks/application_stack.py
+++ b/iac/infrastructure/stacks/application_stack.py
@@ -131,7 +131,7 @@ class ApplicationStack(BaseStack):
         ecs_services = EcsServicesConstruct(
             self,
             "ecs-services",
-            alb_dns_name=Token.as_string(self.alb.alb.dns_name),
+            host_name=f"stormlit.{config.application.domain_name}",
             project_prefix=config.project_prefix,
             environment=config.environment,
             cluster_id=self.ecs_cluster.cluster.id,

--- a/iac/infrastructure/stacks/application_stack.py
+++ b/iac/infrastructure/stacks/application_stack.py
@@ -1,6 +1,6 @@
 from typing import List
 from constructs import Construct
-from cdktf import TerraformOutput, Token, TerraformVariable
+from cdktf import TerraformOutput, TerraformVariable
 from config import EnvironmentConfig
 from .base_stack import BaseStack
 from ..constructs.ecs_iam import EcsIamConstruct


### PR DESCRIPTION
## Problem
When accessing the Keycloak admin console at `https://stormlit.arc-apps.net/auth`, browsers were blocking insecure resource requests due to mixed content warnings. Specifically, Keycloak was attempting to load resources over HTTP even though the page was served over HTTPS, causing errors like:

```
Mixed Content: The page at 'https://stormlit.arc-apps.net/auth/admin/master/console/' was loaded over HTTPS, but requested an insecure resource 'http://stormlit.arc-apps.net/auth/resources/master/admin/en'
```

## Solution
Updated the Keycloak ECS task definition to properly handle HTTPS when running behind AWS Application Load Balancer. Key changes:

1. Added `--proxy-headers=xforwarded` to Keycloak's startup command to enable processing of X-Forwarded-* headers from ALB
2. Configured Keycloak with the correct proxy and HTTPS settings:
   - Set `KC_PROXY=edge` for ALB edge termination
   - Enabled `KC_HOSTNAME_STRICT_HTTPS=true`
   - Set `KC_HTTP_MAX_FORWARDED_HEADER_SIZE=50`
   - Added TLS protocol restrictions
   - Ensured all frontend URLs use HTTPS

## Testing
- Verified that accessing the Keycloak admin console no longer shows mixed content warnings
- Confirmed all resources are now loaded over HTTPS
- Tested login flow works correctly with the new configuration

## References
- [Keycloak Reverse Proxy Documentation](https://www.keycloak.org/server/reverseproxy)