### PR TITLE
Update Docker image tagging strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
             # tag events
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            # branch events
-            type=ref,event=branch
-            # set latest tag for main branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            # branch events - dev branch gets dev tag
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            # main branch gets latest tag
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: [ 'v*' ]
+    tags-ignore: ['*-dev']
 
 concurrency: 
   group: development


### PR DESCRIPTION
## Description
Updates the Docker image tagging strategy in the build workflow to properly handle the new branch structure where 'dev' is the default branch. This change ensures that Docker images are tagged appropriately based on the source branch or git tag.

## Changes
- Modified the docker/metadata-action configuration to:
  - Tag images from 'dev' branch with 'dev' tag
  - Tag images from 'main' branch with 'latest' tag
  - Maintain semantic version tagging for git tags (e.g., v1.0.0, 1.0)
- Removed generic branch-based tagging
- Changed from using `is_default_branch` to explicit branch name checks

## Testing
The changes can be verified by:
1. Creating a PR to dev branch - should build but not push image
2. Merging to dev branch - should build and push with 'dev' tag
3. Merging to main branch - should build and push with 'latest' tag
4. Creating a git tag - should build and push with version tags

## Notes
- I have changed the default branch from main to dev, new pull requests should target dev by default.
- There are environment settings to restrict tags on the dev branch to "v*-dev" and on the main branch to "v*"
