### PR TITLE
Flesh out app Dockerfile; configure STAC_API_URL (temporary)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ wheels/
 .env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/app/.env.template
+++ b/app/.env.template
@@ -1,3 +1,3 @@
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-STAC_API_URL=
+STAC_API_URL=https://stac.ffrd.wspwater.tech

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM mambaorg/micromamba:2.0.5
+FROM mambaorg/micromamba:2.0.5
 
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:2.0.5
+FROM --platform=$TARGETPLATFORM mambaorg/micromamba:2.0.5
 
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,16 +1,13 @@
-# Stage 0: Use BuildKit's multi-platform support
-FROM --platform=$BUILDPLATFORM python:3.12-slim as builder
-
-# Set the working directory in the container
-WORKDIR /app
-
-# Stage 1: Create the final multi-arch image
-FROM --platform=$TARGETPLATFORM python:3.12-slim
+FROM mambaorg/micromamba:2.0.5
 
 WORKDIR /app
 
-# Install streamlit
-RUN pip install --no-cache-dir streamlit
+COPY env.yml env.yml
+COPY src src
+COPY main.py main.py
+
+RUN micromamba install -y -n base -f env.yml && \
+    micromamba clean --all --yes
 
 # Expose the port Streamlit runs on
 EXPOSE 8501
@@ -19,4 +16,4 @@ EXPOSE 8501
 ENV STREAMLIT_SERVER_ADDRESS="0.0.0.0"
 
 # Command to run your application
-CMD ["streamlit", "hello"]
+CMD ["streamlit", "run", "main.py"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,6 +6,8 @@ COPY env.yml env.yml
 COPY src src
 COPY main.py main.py
 
+RUN apt-get update && apt-get install build-essential -y
+
 RUN micromamba install -y -n base -f env.yml && \
     micromamba clean --all --yes
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:2.0.5
+FROM mambaorg/micromamba:2.0.5 as builder
 
 WORKDIR /app
 
@@ -15,6 +15,13 @@ COPY main.py main.py
 
 RUN micromamba install -y -n base -f env.yml && \
     micromamba clean --all --yes
+
+FROM mambaorg/micromamba:2.0.5
+
+COPY --from=builder /opt/conda /opt/conda
+COPY --from=builder /app /app
+
+WORKDIR /app
 
 # Expose the port Streamlit runs on
 EXPOSE 8501

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,12 +1,17 @@
-FROM mambaorg/micromamba:2.0.5
+FROM mambaorg/micromamba:2.0.5 as builder
 
 WORKDIR /app
+
+USER root
+
+RUN apt-get update && apt-get install build-essential -y \
+    && apt-get clean
+
+USER micromamba
 
 COPY env.yml env.yml
 COPY src src
 COPY main.py main.py
-
-RUN apt-get update && apt-get install build-essential -y
 
 RUN micromamba install -y -n base -f env.yml && \
     micromamba clean --all --yes

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:2.0.5 as builder
+FROM mambaorg/micromamba:2.0.5
 
 WORKDIR /app
 
@@ -7,7 +7,7 @@ USER root
 RUN apt-get update && apt-get install build-essential -y \
     && apt-get clean
 
-USER micromamba
+USER mambauser
 
 COPY env.yml env.yml
 COPY src src

--- a/app/env.yml
+++ b/app/env.yml
@@ -9,12 +9,12 @@ dependencies:
 - plotly=5.24.1
 - python=3.12.8
 - pytest=8.3.4
-- rasterio=1.4.3
 - ruff=0.9.1
 - pip:
   - pipenv==2024.4.0
   - pygeohydro==0.18.0
   - python-dotenv==1.0.1
+  - fireducks==1.1.7
   - rashdf==0.7.1
   - scipy==1.15.1
   - shapely==2.0.6

--- a/app/env.yml
+++ b/app/env.yml
@@ -14,7 +14,6 @@ dependencies:
   - pipenv==2024.4.0
   - pygeohydro==0.18.0
   - python-dotenv==1.0.1
-  - fireducks==1.1.7
   - rashdf==0.7.1
   - scipy==1.15.1
   - shapely==2.0.6

--- a/app/env.yml
+++ b/app/env.yml
@@ -9,8 +9,8 @@ dependencies:
 - plotly=5.24.1
 - python=3.12.8
 - pytest=8.3.4
+- rasterio=1.4.3
 - ruff=0.9.1
-- gdal
 - pip:
   - pipenv==2024.4.0
   - pygeohydro==0.18.0

--- a/app/env.yml
+++ b/app/env.yml
@@ -10,6 +10,7 @@ dependencies:
 - python=3.12.8
 - pytest=8.3.4
 - ruff=0.9.1
+- gdal
 - pip:
   - pipenv==2024.4.0
   - pygeohydro==0.18.0

--- a/app/env.yml
+++ b/app/env.yml
@@ -9,6 +9,7 @@ dependencies:
 - plotly=5.24.1
 - python=3.12.8
 - pytest=8.3.4
+- rasterio=1.4.3
 - ruff=0.9.1
 - pip:
   - pipenv==2024.4.0

--- a/iac/infrastructure/constructs/ecs_services.py
+++ b/iac/infrastructure/constructs/ecs_services.py
@@ -208,6 +208,10 @@ class EcsServicesConstruct(Construct):
                     {"name": "STREAMLIT_SERVER_PORT", "value": "8501"},
                     {"name": "STREAMLIT_SERVER_ADDRESS", "value": "0.0.0.0"},
                     {"name": "STREAMLIT_BROWSER_GATHER_USAGE_STATS", "value": "false"},
+                    {
+                        "name": "STAC_API_URL",
+                        "value": "https://stac.ffrd.wspwater.tech",
+                    },
                 ],
                 "logConfiguration": {
                     "logDriver": "awslogs",


### PR DESCRIPTION
# Description
* Modifies the existing `app/Dockerfile` to create a basic image spec for the primary stormlit app container.
* Sets the `STAC_API_URL` to point to an existing STAC API deployment. 
  * Includes this URL in `app/.env.template`

# Notes
We're currently missing `stac-fastapi` from our environment. Once that is integrated, the `STAC_API_URL` environment variable will need to be modified to point to the appropriate instance (i.e., locally in `.devcontainer/docker-compose.yml` or on AWS).