### PR TITLE
Feature/stac browser

### DIFF
--- a/app/.env.template
+++ b/app/.env.template
@@ -2,3 +2,4 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 STAC_API_URL=https://stac.ffrd.wspwater.tech
 STAC_BROWSER_URL=https://fema-ffrd.github.io/stac-browser
+LOCAL_FILE_DIRECTORY=/workspace/catalog

--- a/app/.env.template
+++ b/app/.env.template
@@ -1,3 +1,4 @@
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 STAC_API_URL=https://stac.ffrd.wspwater.tech
+STAC_BROWSER_URL=https://fema-ffrd.github.io/stac-browser

--- a/app/src/pages/view_gages.py
+++ b/app/src/pages/view_gages.py
@@ -1,16 +1,17 @@
 # module imports
-from ..utils.stac_data import init_gage_data
-from ..utils.session import init_session_state
+# standard imports
+import os
+
+import plotly.graph_objects as go
+import streamlit as st
+from dotenv import load_dotenv
+from scipy.stats import norm
+
 from ..components.layout import render_footer
 from ..components.tables import stylized_table
 from ..configs.settings import LOG_LEVEL
-
-# standard imports
-import os
-import streamlit as st
-from scipy.stats import norm
-from dotenv import load_dotenv
-import plotly.graph_objects as go
+from ..utils.session import init_session_state
+from ..utils.stac_data import init_gage_data
 
 # global variables
 GAGES_DATA = "s3://kanawha-pilot/stac/Kanawha-0505/data-summary/gages.pq"
@@ -22,8 +23,6 @@ load_dotenv()
 def view_gages():
     if "session_id" not in st.session_state:
         init_session_state()
-
-    st.stac_url = os.getenv("STAC_API_URL")
 
     st.session_state.log_level = LOG_LEVEL
 

--- a/app/src/pages/view_storms.py
+++ b/app/src/pages/view_storms.py
@@ -1,18 +1,20 @@
 # module imports
-from ..configs.settings import LOG_LEVEL
-from ..utils.stac_data import init_storm_data
-from ..utils.session import init_session_state
-from ..components.layout import render_footer
-
 # standard imports
 import os
+
 import folium
 import geopandas as gpd
 import streamlit as st
+from dotenv import load_dotenv
 from shapely import wkt
 from shapely.geometry import Point
 from streamlit_folium import st_folium
-from dotenv import load_dotenv
+
+from ..components.layout import render_footer
+from ..components.tables import stylized_table
+from ..configs.settings import LOG_LEVEL
+from ..utils.session import init_session_state
+from ..utils.stac_data import init_storm_data
 
 # global variables
 STORMS_DATA = "s3://kanawha-pilot/stac/Kanawha-0505/data-summary/storms.pq"
@@ -31,7 +33,6 @@ def view_storms():
     if "session_id" not in st.session_state:
         init_session_state()
 
-    st.stac_url = os.getenv("STAC_API_URL")
 
     st.session_state.log_level = LOG_LEVEL
 
@@ -39,8 +40,8 @@ def view_storms():
         st.write("Initializing datasets...")
         init_storm_data(STORMS_DATA)
         st.session_state["init_storm_data"] = True
-        st.balloons()
-        st.success("Complete! Storm data is now ready for exploration.")
+        # st.balloons()
+        # st.success("Complete! Storm data is now ready for exploration.")
 
     st.markdown("## Storm Viewer")
 
@@ -110,7 +111,11 @@ def view_storms():
         sieve1 = sieve1[sieve1["Date"].isin(st.session_state["storm_date"])]
 
     st.write("Filtered Dataset")
-    st.dataframe(sieve1)
+
+    stylized_table(
+                sieve1[["ID", "event", "Block","Realization","Date","Season", "Link", "Max Precip (in)"]].sort_values(by="Max Precip (in)", ascending=True)
+            )
+
 
     if len(sieve1) > 0:
         # Create a gdf for the SST storm center points
@@ -127,11 +132,11 @@ def view_storms():
 
         # initialize the maps
         m1 = folium.Map(location=[37.75153, -80.94911], zoom_start=6)
-        folium.GeoJson(f"{st.stac_url}/collections/Kanawha-R01/items/E005125").add_to(
+        folium.GeoJson(f"{st.session_state.stac_api}/collections/Kanawha-R01/items/E005125").add_to(
             m1
         )
         m2 = folium.Map(location=[37.75153, -80.94911], zoom_start=6)
-        folium.GeoJson(f"{st.stac_url}/collections/Kanawha-R01/items/E005125").add_to(
+        folium.GeoJson(f"{st.session_state.stac_api}/collections/Kanawha-R01/items/E005125").add_to(
             m2
         )
 

--- a/app/src/pages/view_storms.py
+++ b/app/src/pages/view_storms.py
@@ -33,15 +33,12 @@ def view_storms():
     if "session_id" not in st.session_state:
         init_session_state()
 
-
     st.session_state.log_level = LOG_LEVEL
 
     if st.session_state["init_storm_data"] is False:
         st.write("Initializing datasets...")
         init_storm_data(STORMS_DATA)
         st.session_state["init_storm_data"] = True
-        # st.balloons()
-        # st.success("Complete! Storm data is now ready for exploration.")
 
     st.markdown("## Storm Viewer")
 
@@ -113,9 +110,19 @@ def view_storms():
     st.write("Filtered Dataset")
 
     stylized_table(
-                sieve1[["ID", "event", "Block","Realization","Date","Season", "Link", "Max Precip (in)"]].sort_values(by="Max Precip (in)", ascending=True)
-            )
-
+        sieve1[
+            [
+                "ID",
+                "event",
+                "Block",
+                "Realization",
+                "Date",
+                "Season",
+                "Link",
+                "Max Precip (in)",
+            ]
+        ].sort_values(by="Max Precip (in)", ascending=True)
+    )
 
     if len(sieve1) > 0:
         # Create a gdf for the SST storm center points
@@ -132,13 +139,13 @@ def view_storms():
 
         # initialize the maps
         m1 = folium.Map(location=[37.75153, -80.94911], zoom_start=6)
-        folium.GeoJson(f"{st.session_state.stac_api}/collections/Kanawha-R01/items/E005125").add_to(
-            m1
-        )
+        folium.GeoJson(
+            f"{st.session_state.stac_api_url}/collections/Kanawha-R01/items/E005125"
+        ).add_to(m1)
         m2 = folium.Map(location=[37.75153, -80.94911], zoom_start=6)
-        folium.GeoJson(f"{st.session_state.stac_api}/collections/Kanawha-R01/items/E005125").add_to(
-            m2
-        )
+        folium.GeoJson(
+            f"{st.session_state.stac_api_url}/collections/Kanawha-R01/items/E005125"
+        ).add_to(m2)
 
         # create a heatmap for the historic storm center points
         folium.plugins.HeatMap(

--- a/app/src/utils/local_server.py
+++ b/app/src/utils/local_server.py
@@ -7,6 +7,7 @@ from dotenv import find_dotenv, load_dotenv
 
 load_dotenv(find_dotenv())
 
+
 class CORSRequestHandler(SimpleHTTPRequestHandler):
     def end_headers(self):
         self.send_header("Access-Control-Allow-Origin", "*")
@@ -23,7 +24,9 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
         list.sort(key=lambda a: a.lower())
         r = []
         displaypath = self.path
-        r.append(f"<!DOCTYPE html><html><head><title>Directory listing for {displaypath}</title></head>")
+        r.append(
+            f"<!DOCTYPE html><html><head><title>Directory listing for {displaypath}</title></head>"
+        )
         r.append(
             '<div style="text-align: right; margin: 20px;"><button style="background-color: #2986cc; color: \
              white; padding: 10px 20px; border: none; border-radius: 5px; font-size: 16px; cursor: pointer;" \
@@ -95,10 +98,10 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     """Handle requests in a separate thread."""
 
 
-def serve(local_dir:str):
+def serve(local_dir: str):
     os.chdir(local_dir)
     host = "0.0.0.0"
-    port =  5000
+    port = 5000
 
     print(f"Serving '{local_dir}' on {host}:{port}")
     httpd = ThreadedHTTPServer((host, port), CORSRequestHandler)

--- a/app/src/utils/local_server.py
+++ b/app/src/utils/local_server.py
@@ -1,0 +1,117 @@
+import os
+import webbrowser
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from socketserver import ThreadingMixIn
+
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv())
+
+class CORSRequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "x-api-key, Content-Type")
+        SimpleHTTPRequestHandler.end_headers(self)
+
+    def list_directory(self, path):
+        try:
+            list = os.listdir(path)
+        except OSError:
+            self.send_error(404, "No permission to list directory")
+            return None
+        list.sort(key=lambda a: a.lower())
+        r = []
+        displaypath = self.path
+        r.append(f"<!DOCTYPE html><html><head><title>Directory listing for {displaypath}</title></head>")
+        r.append(
+            '<div style="text-align: right; margin: 20px;"><button style="background-color: #2986cc; color: \
+             white; padding: 10px 20px; border: none; border-radius: 5px; font-size: 16px; cursor: pointer;" \
+             onclick="stopServer()">🛑 Stop Server</button></div>'
+        )
+
+        r.append(
+            f'<h3><a href="{os.getenv("STAC_BROWSER_URL")}#/external/{os.getenv("STAC_API_URL")}" target="_blank">Production STAC Browser</a></h3>'
+        )
+
+        r.append(
+            f'<h3><a href="{os.getenv("STAC_BROWSER_URL")}#/external/http://localhost:{self.server.server_port}/catalog.json" target="_blank">Local STAC Browser</a></h3>'
+        )
+
+        r.append(f"<body><h4>Local directory listing for {displaypath}</h4>")
+
+        r.append(
+            """
+            <script>
+                function stopServer() {
+                    fetch('/shutdown', { method: 'POST' })
+                    .then(response => response.text())
+                    .then(data => {
+                        alert(data);
+                        window.close();
+                    })
+                    .catch(error => alert('Failed to stop server'));
+                }
+            </script>
+        """
+        )
+
+        r.append("<hr><ul>")
+        for name in list:
+            fullname = os.path.join(path, name)
+            displayname = name
+            linkname = name
+            if os.path.isdir(fullname):
+                displayname = name + "/"
+                linkname = name + "/"
+            r.append(f'<li><a href="{linkname}">{displayname}</a></li>')
+        r.append("</ul><hr>")
+        r.append("</body></html>")
+        encoded = "\n".join(r).encode("utf-8", "surrogateescape")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+        return None
+
+    def do_POST(self):
+        if self.path == "/shutdown":
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"Server is shutting down...")
+            print("Shutting down the server...")
+
+            def shutdown():
+                self.server.shutdown()
+
+            import threading
+
+            threading.Thread(target=shutdown).start()
+
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """Handle requests in a separate thread."""
+
+
+def serve(local_dir:str):
+    os.chdir(local_dir)
+    host = "0.0.0.0"
+    port =  5000
+
+    print(f"Serving '{local_dir}' on {host}:{port}")
+    httpd = ThreadedHTTPServer((host, port), CORSRequestHandler)
+
+    url = f"http://localhost:{port}/"
+    webbrowser.open(url)
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down the server.")
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    serve(local_dir=os.getenv("LOCAL_FILE_DIRECTORY"))

--- a/app/src/utils/session.py
+++ b/app/src/utils/session.py
@@ -15,5 +15,5 @@ def init_session_state():
     st.session_state["realization"] = None
     st.session_state["block"] = None
     st.session_state["search_id"] = None
-    st.session_state["stac_api"] = os.getenv("STAC_API_URL")
-    st.session_state["stac_browser"] = os.getenv("STAC_BROWSER_URL")
+    st.session_state["stac_api_url"] = os.getenv("STAC_API_URL")
+    st.session_state["stac_browser_url"] = os.getenv("STAC_BROWSER_URL")

--- a/app/src/utils/session.py
+++ b/app/src/utils/session.py
@@ -1,5 +1,7 @@
-import streamlit as st
+import os
 from datetime import datetime
+
+import streamlit as st
 
 
 def init_session_state():
@@ -13,3 +15,5 @@ def init_session_state():
     st.session_state["realization"] = None
     st.session_state["block"] = None
     st.session_state["search_id"] = None
+    st.session_state["stac_api"] = os.getenv("STAC_API_URL")
+    st.session_state["stac_browser"] = os.getenv("STAC_BROWSER_URL")

--- a/app/src/utils/stac_data.py
+++ b/app/src/utils/stac_data.py
@@ -3,7 +3,7 @@ import streamlit as st
 
 
 def generate_stac_item_link(base_url, collection_id, item_id):
-    return f"https://radiantearth.github.io/stac-browser/#/external/{base_url}/collections/{collection_id}/items/{item_id}"
+    return f"{st.session_state.stac_browser}/#/external/{base_url}/collections/{collection_id}/items/{item_id}"
 
 
 @st.cache_data
@@ -15,7 +15,7 @@ def fetch_collection_data(collection_id, _progress_bar):
     total_items = len(items)
 
     for idx, item in enumerate(items):
-        stac_item_link = f"https://radiantearth.github.io/stac-browser/#/external/{st.session_state.stac_url}/collections/{collection_id}/items/{item.id}"
+        stac_item_link = f"{st.session_state.stac_browser}/#/external/{st.session_state.stac_api}/collections/{collection_id}/items/{item.id}"
 
         event = item.properties.get("event", "N/A")
         block_group = item.properties.get("block_group", "N/A")
@@ -50,14 +50,14 @@ def fetch_collection_data(collection_id, _progress_bar):
 
 
 def collection_id(realization):
-    return f"Kanawha-0505-R{realization:03}"
+    return f"Kanawha-R{realization:02}"
 
 
 @st.cache_data
 def init_storm_data(storms_pq_path: str):
     st.storms = pd.read_parquet(storms_pq_path, engine="pyarrow")
     st.storms["Link"] = st.storms.apply(
-        lambda row: f'<a href="{generate_stac_item_link(st.stac_url, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
+        lambda row: f'<a href="{generate_stac_item_link(st.session_state.stac_api, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
         axis=1,
     )
 
@@ -66,7 +66,7 @@ def init_storm_data(storms_pq_path: str):
 def init_gage_data(gages_pq_path: str):
     st.gages = pd.read_parquet(gages_pq_path, engine="pyarrow")
     st.gages["Link"] = st.gages.apply(
-        lambda row: f'<a href="{generate_stac_item_link(st.stac_url, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
+        lambda row: f'<a href="{generate_stac_item_link(st.session_state.stac_api, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
         axis=1,
     )
 

--- a/app/src/utils/stac_data.py
+++ b/app/src/utils/stac_data.py
@@ -15,7 +15,7 @@ def fetch_collection_data(collection_id, _progress_bar):
     total_items = len(items)
 
     for idx, item in enumerate(items):
-        stac_item_link = f"{st.session_state.stac_browser}/#/external/{st.session_state.stac_api}/collections/{collection_id}/items/{item.id}"
+        stac_item_link = f"{st.session_state.stac_browser}/#/external/{st.session_state.stac_api_url}/collections/{collection_id}/items/{item.id}"
 
         event = item.properties.get("event", "N/A")
         block_group = item.properties.get("block_group", "N/A")
@@ -57,7 +57,7 @@ def collection_id(realization):
 def init_storm_data(storms_pq_path: str):
     st.storms = pd.read_parquet(storms_pq_path, engine="pyarrow")
     st.storms["Link"] = st.storms.apply(
-        lambda row: f'<a href="{generate_stac_item_link(st.session_state.stac_api, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
+        lambda row: f'<a href="{generate_stac_item_link(st.session_state.stac_api_url, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
         axis=1,
     )
 
@@ -66,7 +66,7 @@ def init_storm_data(storms_pq_path: str):
 def init_gage_data(gages_pq_path: str):
     st.gages = pd.read_parquet(gages_pq_path, engine="pyarrow")
     st.gages["Link"] = st.gages.apply(
-        lambda row: f'<a href="{generate_stac_item_link(st.session_state.stac_api, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
+        lambda row: f'<a href="{generate_stac_item_link(st.session_state.stac_api_url, collection_id(row["realization"]), row["ID"])}" target="_blank">See in Catalog</a>',
         axis=1,
     )
 

--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,0 +1,7 @@
+{
+    "type": "Catalog",
+    "id": "local-catalog",
+    "stac_version": "1.0.0",
+    "description": "Local catalog for testing",
+    "links": []
+}


### PR DESCRIPTION
# Description
* Replaces the radiant earth hosted stac browser with [fema-ffrd hosted browser](https://fema-ffrd.github.io/stac-browser/#/?.language=en).
  * Adds the `STAC_BROWSER_URL` env variable. 
  * Fixes the issue where decimals are shown as commas in the browser.

* Fixes broken links in existing proof-of-concept gages and storms tables.

* Adds a local file server for viewing stac objects served locally for review / testing.

# Notes
We will want to discuss details of the local file server, particularly with respect to multi-users. Maybe this will be for developers only for the time being. 

Also the auto-save / format option moved some imports around, will need to review and ensure the current behavior / settings are what is desired.

Closes #6 
Closes #1