### PR TITLE
Optionally set CA bundle in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,3 +2,8 @@ FROM mcr.microsoft.com/devcontainers/base:jammy
 
 # copy micromamba environment file
 COPY app/env.yml /tmp/env.yml
+
+# Install additional trusted CAs for developer environments (e.g., Zscaler)
+COPY .devcontainer/*.crt /tmp/
+COPY .devcontainer/install-custom-ca.sh /tmp/install-custom-ca.sh
+RUN /tmp/install-custom-ca.sh

--- a/.devcontainer/install-custom-ca.sh
+++ b/.devcontainer/install-custom-ca.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+set -e
+
+# Custom CA files
+custom_ca=$(find /tmp -maxdepth 1 -name "*.crt")
+if [ -z "$custom_ca" ]; then
+    echo "No custom CA files provided."
+    exit 0
+fi
+
+# Add custom CA files to /usr/local/share/ca-certificates
+cp $custom_ca /usr/local/share/ca-certificates/
+
+update-ca-certificates

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ coverage.xml
 # AWS
 .aws/
 *.pem
+
+# Root CA certificates
+.devcontainer/*.crt

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ code .
 If encountering SSL errors in building dev container
 environment, check if you are on a corporate VPN which
 does man-in-the-middle SSL inspection with certificate
-replacement (e.g., Zscaler). Programs running in the
-dev container needs to "trust" the Root Certificate
+replacement (e.g., Zscaler). Programs running within the
+dev container need to "trust" the Root Certificate
 Authority of your VPN.
 
 Obtain the Root CA in `PEM` format, put it in a text

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ code .
    - Python environment is pre-configured
    - Terminal in VS Code uses the container environment
 
+#### Setup Troubleshooting: SSL Errors in VPN Environments
+If encountering SSL errors in building dev container
+environment, check if you are on a corporate VPN which
+does man-in-the-middle SSL inspection with certificate
+replacement (e.g., Zscaler). Programs running in the
+dev container needs to "trust" the Root Certificate
+Authority of your VPN.
+
+Obtain the Root CA in `PEM` format, put it in a text
+file with the extension `.crt`, and place it in the
+`./devcontainer/` folder. Then, rebuild the dev
+container environment.
+
+Further configuration may be necessary.
+
 ### Base Image and Features
 - Base image: `mcr.microsoft.com/devcontainers/base:jammy`
 - Python environment managed by Micromamba


### PR DESCRIPTION
# Description
Modifies the `.devcontainer/Dockerfile` to optionally install custom CA certificates. Allows the environment to build properly behind corporate VPNs.

# Testing
* Rebuild the devcontainers environment and confirm that everything works normally.
* If behind a corporate VPN that does cert replacement, try adding the VPN's Root CA in `PEM` format to `.devcontainer/` before rebuilding.

# Notes
Once I'm able to run the full dev container build (WSP blocks many Anaconda resources, hence `micromamba` falls to install... 🙄) I'll likely have a follow on PR to optionally set certain environment variables to that Python, Node, etc. respect the installed custom CA.