### PR TITLE
Layered Docker Compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "stormlit-devcontainer",
-	"dockerComposeFile": "docker-compose.yml",
+	"dockerComposeFile": ["../docker-compose.yml", "docker-compose.devcontainer.yml"],
 	"service": "stormlit-app",
 	"workspaceFolder": "/workspace",
 	"features": {

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -3,8 +3,8 @@ version: '3.8'
 services:
   stormlit-app:
     build:
-      context: ..
+      context: .
       dockerfile: .devcontainer/Dockerfile
     command: sleep infinity
     volumes:
-      - ..:/workspace:cached
+      - .:/workspace:cached

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  stormlit-app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    command: sleep infinity
+    volumes:
+      - ..:/workspace:cached

--- a/.devcontainer/install-custom-ca.sh
+++ b/.devcontainer/install-custom-ca.sh
@@ -1,8 +1,11 @@
 #! /usr/bin/env bash
 set -e
 
-# Custom CA files
-custom_ca=$(find /tmp -maxdepth 1 -name "*.crt")
+# Get the path of this script's parent directory
+script_dir=$(dirname "$(realpath "$0")")
+
+# Find custom CA files placed in the container
+custom_ca=$(find $script_dir -maxdepth 1 -name "*.crt")
 if [ -z "$custom_ca" ]; then
     echo "No custom CA files provided."
     exit 0

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ git clone https://github.com/fema-ffrd/stormlit
 cd stormlit
 ```
 
+#### VS Code Dev Container Setup
+If not using dev containers, skip to
+[Docker Compose Setup](#docker-compose-setup) below.
 2. Open in VS Code:
 ```bash
 code .
@@ -37,6 +40,20 @@ code .
    - Select your project folder
    - Wait for container build (~5-10 minutes first time)
 
+Continue to [Verify Services](#verify-services).
+
+#### Docker Compose Setup
+2. Build Docker images for the environment.
+```bash
+docker compose build
+```
+
+3. Start the application and services.
+```bash
+docker compose up
+```
+
+#### Verify Services
 4. Verify services:
    - Open browser: http://localhost:50080 (Keycloak)
      - Login: admin/admin
@@ -58,7 +75,7 @@ code .
    - Terminal in VS Code uses the container environment
 
 #### Setup Troubleshooting: SSL Errors in VPN Environments
-If encountering SSL errors in building dev container
+If encountering SSL errors while building the dev container
 environment, check if you are on a corporate VPN which
 does man-in-the-middle SSL inspection with certificate
 replacement (e.g., Zscaler). Programs running within the

--- a/README.md
+++ b/README.md
@@ -68,9 +68,22 @@ Authority of your VPN.
 Obtain the Root CA in `PEM` format, put it in a text
 file with the extension `.crt`, and place it in the
 `./devcontainer/` folder. Then, rebuild the dev
-container environment.
+container environment. This will allow the dev container
+to build without SSL errors.
 
-Further configuration may be necessary.
+Additonal configuration may be necessary to allow the
+Stormlit app container to connect to online resources
+without SSL errors. First, create a CA bundle by
+concatenating the Root CA with, e.g., [the Mozilla
+certificate bundle distributed with the Python certifi
+library](https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem),
+and name it with a `.crt` extension. Then, modify
+your `./app/.env` file with environment variables
+to ensure that Stormlit uses the Root CA:
+```sh
+REQUESTS_CA_BUNDLE=/workspace/.devcontainer/zscaler-certifi-ca-bundle.crt
+SSL_CERT_FILE=/workspace/.devcontainer/zscaler-certifi-ca-bundle.crt
+```
 
 ### Base Image and Features
 - Base image: `mcr.microsoft.com/devcontainers/base:jammy`

--- a/app/src/utils/stac_data.py
+++ b/app/src/utils/stac_data.py
@@ -3,7 +3,7 @@ import streamlit as st
 
 
 def generate_stac_item_link(base_url, collection_id, item_id):
-    return f"{st.session_state.stac_browser}/#/external/{base_url}/collections/{collection_id}/items/{item_id}"
+    return f"{st.session_state.stac_browser_url}/#/external/{base_url}/collections/{collection_id}/items/{item_id}"
 
 
 @st.cache_data
@@ -15,7 +15,7 @@ def fetch_collection_data(collection_id, _progress_bar):
     total_items = len(items)
 
     for idx, item in enumerate(items):
-        stac_item_link = f"{st.session_state.stac_browser}/#/external/{st.session_state.stac_api_url}/collections/{collection_id}/items/{item.id}"
+        stac_item_link = f"{st.session_state.stac_browser_url}/#/external/{st.session_state.stac_api_url}/collections/{collection_id}/items/{item.id}"
 
         event = item.properties.get("event", "N/A")
         block_group = item.properties.get("block_group", "N/A")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,14 @@ services:
   stormlit-app:
     container_name: stormlit-app
     build: 
-      context: ..
-      dockerfile: .devcontainer/Dockerfile
+      context: ./app
+    env_file:
+      - ./app/.env
+    ports:
+      - "8501:8501"
     volumes:
-      - ..:/workspace:cached
-    command: sleep infinity
+      - .:/workspace:cached
+      - ./app:/app
     networks:
       - stormlit-network
 


### PR DESCRIPTION
# Description
Modifies the development environment slightly to suit my needs, hopefully without impacting others.

I'm having trouble with the dev container environment as-is because it reaches out to `api.anaconda.org` to download and install `micromamba`, but the `anaconda.org` domain is blocked on the WSP network. ☹

Instead, I've separated out the `./.devcontainer/docker-compose.yml` into two files. Instead of using the dev container, I'm just running the new `docker-compose.yml` file in the project root. The `./.devcontainer/docker-compose.devcontainer.yml` file now simply layers a few changes on top of `./docker-compose.yml`.

# Testing
* Run `docker compose up` from the project root to launch the stormlit environment without dev containers. Confirm that things work as expected.
* Spin up the dev container environment and confirm that things work as they did before.

# Notes
This is branched from #22.

