### PR TITLE
Grant ECS task exec role permission to read S3

### DIFF
--- a/iac/infrastructure/constructs/ecs_iam.py
+++ b/iac/infrastructure/constructs/ecs_iam.py
@@ -126,6 +126,14 @@ class EcsIamConstruct(Construct):
                     ],
                     "Resource": "*",
                 },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:GetObject",
+                        "s3:ListBucket",
+                    ],
+                    "Resource": "*",
+                }
             ],
         }
 


### PR DESCRIPTION
# Description
* Dev deployment is currently broken because Stormlit app isn't able to read data from S3.
* This PR grants read-only permission to AWS ECS tasks.