### PR TITLE
Switch S3 policy from ECS task execution role to ECS task role

### DIFF
--- a/iac/infrastructure/constructs/ecs_iam.py
+++ b/iac/infrastructure/constructs/ecs_iam.py
@@ -210,7 +210,15 @@ class EcsIamConstruct(Construct):
                             "Service": "ecs-tasks.amazonaws.com"
                         },
                         "Effect": "Allow"
-                    }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject",
+                            "s3:ListBucket",
+                        ],
+                        "Resource": "*",
+                    },
                 ]
             }""",
             tags=tags,

--- a/iac/infrastructure/constructs/ecs_iam.py
+++ b/iac/infrastructure/constructs/ecs_iam.py
@@ -126,14 +126,6 @@ class EcsIamConstruct(Construct):
                     ],
                     "Resource": "*",
                 },
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:ListBucket",
-                    ],
-                    "Resource": "*",
-                },
             ],
         }
 


### PR DESCRIPTION
# Description
Fixes recent deployment #24 to switch the S3 policy placement from ECS task execution role to ECS task role.

# Notes
Merging directly to `main` to reduce PR back-and-forth in case there's more to do. Will open a follow-up PR to merge `main` to `dev` if this succeeds.