### PR TITLE
update IaC to set required environment vars for dev deployment

### DIFF
--- a/iac/infrastructure/stacks/application_stack_dev.py
+++ b/iac/infrastructure/stacks/application_stack_dev.py
@@ -108,6 +108,14 @@ class ApplicationStackDev(BaseStack):
                         "name": "STREAMLIT_BROWSER_GATHER_USAGE_STATS",
                         "value": "false",
                     },
+                    {
+                        "name": "STAC_API_URL",
+                        "value": "https://stac.ffrd.wspwater.tech",
+                    },
+                    {
+                        "name": "STAC_BROWSER_URL",
+                        "value": "https://fema-ffrd.github.io/stac-browser",
+                    },
                 ],
                 "logConfiguration": {
                     "logDriver": "awslogs",


### PR DESCRIPTION
# Description
Updates environment variables for the "dev" deployment of the Stormlit app. These variables are currently missing from the dev deployment since they were only added to `./iac/infrastructure/constructs/ecs_services.py`. The application is mostly functioning since deployment of #28, but with these environment variables missing, links to the STAC browser are currently broken and STAC items can't be pulled from the STAC API.