### PR TITLE
don't cache 'init_pilot'

### DIFF
--- a/app/src/utils/stac_data.py
+++ b/app/src/utils/stac_data.py
@@ -44,7 +44,6 @@ def prep_df(df: pd.DataFrame, layer: str):
     return df
 
 
-@st.cache_data
 def init_pilot(pilot: str):
     """
     Initialize the map data for the selected pilot study


### PR DESCRIPTION
# Description
Closes #44 -- error on "View Map" page when the application is refreshed, due to use of the `st.cache_data` decorator alongside cache-like measures in `view_map.py`.