### PR TITLE
Stac api cors

### DIFF
--- a/iac/infrastructure/constructs/ecs_services.py
+++ b/iac/infrastructure/constructs/ecs_services.py
@@ -164,6 +164,8 @@ class EcsServicesConstruct(Construct):
                         {"name": "POSTGRES_PORT", "value": "5432"},
                         {"name": "POSTGRES_DBNAME", "value": "postgres"},
                         {"name": "ROOT_PATH", "value": ""},
+                        {"name": "CORS_ORIGIN", "value": "*"},
+                        {"name": "CORS_METHODS", "value": "*"},
                     ],
                     "logConfiguration": {
                         "logDriver": "awslogs",


### PR DESCRIPTION
Environment variable additions:

* [`iac/infrastructure/constructs/ecs_services.py`](diffhunk://#diff-f6aad94228107f6f70b019f8d1c4623c1edcc6a72bf9399e09cdd6594b9d93c2R167-R168): Added `CORS_ORIGIN` and `CORS_METHODS` environment variables with default values of `"*"` to enable CORS support from all origins.