### PR TITLE
Add ingress rule for PostgreSQL access from Stormlit Bastion to RDS security group

### DIFF
--- a/iac/infrastructure/constructs/networking.py
+++ b/iac/infrastructure/constructs/networking.py
@@ -262,6 +262,17 @@ class NetworkingConstruct(Construct):
         )
         SecurityGroupRule(
             self,
+            "rds-vpc-ingress",
+            type="ingress",
+            security_group_id=self.rds_security_group.id,
+            from_port=5432,
+            to_port=5432,
+            protocol="tcp",
+            source_security_group_id="sg-0913eaec57c161f18", # Stormlit Bastion SG
+            description="Allow PostgreSQL access from Stormlit Bastion",
+        )
+        SecurityGroupRule(
+            self,
             "rds-egress",
             type="egress",
             security_group_id=self.rds_security_group.id,

--- a/iac/infrastructure/constructs/networking.py
+++ b/iac/infrastructure/constructs/networking.py
@@ -262,7 +262,7 @@ class NetworkingConstruct(Construct):
         )
         SecurityGroupRule(
             self,
-            "rds-vpc-ingress",
+            "rds-vpc-bastion-ingress",
             type="ingress",
             security_group_id=self.rds_security_group.id,
             from_port=5432,

--- a/iac/infrastructure/constructs/networking.py
+++ b/iac/infrastructure/constructs/networking.py
@@ -268,7 +268,7 @@ class NetworkingConstruct(Construct):
             from_port=5432,
             to_port=5432,
             protocol="tcp",
-            source_security_group_id="sg-0913eaec57c161f18", # Stormlit Bastion SG
+            source_security_group_id="sg-0913eaec57c161f18",  # Stormlit Bastion SG
             description="Allow PostgreSQL access from Stormlit Bastion",
         )
         SecurityGroupRule(


### PR DESCRIPTION
This pull request adds a new security group rule to allow PostgreSQL access from the Stormlit Bastion to the RDS instance in the `iac/infrastructure/constructs/networking.py` file.

Networking enhancements:

* Added a new `SecurityGroupRule` for ingress traffic to allow connections on port 5432 (PostgreSQL) from the Stormlit Bastion security group (`sg-0913eaec57c161f18`). This ensures that the RDS instance can be accessed securely from the Bastion host.…ecurity group