### PR TITLE
bump Python version to 3.13 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pipenv'
 
       - name: Setup Node.js


### PR DESCRIPTION
This pull request updates the Python version used in the deployment workflow to ensure compatibility with the project requirements.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L49-R49): Updated the `python-version` from `3.12` to `3.13` in the `Setup Python` step.