### PR TITLE
Fix duck db credentials

### DIFF
--- a/app/src/db/utils.py
+++ b/app/src/db/utils.py
@@ -37,7 +37,7 @@ def create_pg_connection():
     return conn
 
 
-def create_s3_connection():
+def create_s3_connection(aws_region: str = "us-east-1"):
     """
     Create a connection to an S3 account using DuckDB.
 
@@ -50,9 +50,6 @@ def create_s3_connection():
     conn = duckdb.connect()
     conn.execute("INSTALL 'httpfs'")
     conn.execute("LOAD 'httpfs'")
-
-    conn.execute(f"SET s3_access_key_id='{os.getenv('AWS_ACCESS_KEY_ID')}'")
-    conn.execute(f"SET s3_secret_access_key='{os.getenv('AWS_SECRET_ACCESS_KEY')}'")
-    conn.execute(f"SET s3_region='{os.getenv('AWS_REGION')}'")
+    conn.execute(f"SET s3_region='{aws_region}'")
     st.session_state["s3_connected"] = True
     return conn


### PR DESCRIPTION
Fixes this error:

![image](https://github.com/user-attachments/assets/01c3b0a2-138d-4e6f-b876-f7758721c7a6)

This occurs because the `create_s3_connection` was setting aws access keys from environment variables during the connection creation forcing this to be only valid way of authenticating. In general, it should not be assumed which method the connection should be authenticated with and we should leave it up to the library to determine this. For example, by removing these lines, it will follow the normal order of precedence for AWS credentials. See https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-authentication.html#cli-chap-authentication-precedence this will work in development by setting access keys in your environment variables and will work in production where we use EC2 instance credentials.