### PR TITLE
Rewrite Dockerfile to use Ubuntu 24.04 base image instead of Debian to resolve CVE-2025-6020

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ${{ needs.build-streamlit-image.outputs.image_tag }}
+          image: local://${{ needs.build-streamlit-image.outputs.image_tag }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,10 +72,29 @@ jobs:
   docker-scout:
     needs: build-streamlit-image
     if: always()
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    uses: ./.github/workflows/docker-scout.yml
-    with:
-      image_tag: ${{ needs.build-streamlit-image.outputs.image_tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
-    secrets: inherit
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Docker Scout CVE scan on built image
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ${{ needs.build-streamlit-image.outputs.image_tag }}
+          only-severities: critical,high
+          summary: true
+          exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
+          image: local://ghcr.io/fema-ffrd/stormlit:${{ steps.meta.outputs.version }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: local://ghcr.io/fema-ffrd/stormlit:${{ steps.meta.outputs.version }}
+          image: ${{ steps.meta.outputs.tags }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Log in to Docker Hub for Scout
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+
       - name: Run Docker Scout CVE scan on built image
         uses: docker/scout-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
         type: string
         default: 'linux/amd64,linux/arm64'
         required: false
+    outputs:
+      image_tag:
+        description: 'Docker image tags'
+        value: ${{ jobs.build-streamlit-image.outputs.image_tag }}
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       packages: write
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
+      first_tag: ${{ steps.first-tag.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -56,6 +57,12 @@ jobs:
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             # main branch gets latest tag
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # PR builds get a unique tag based on PR number and commit
+            type=ref,event=pr
+
+      - name: Extract first tag for Docker Scout
+        id: first-tag
+        run: echo "tag=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         id: build
@@ -94,7 +101,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: local://${{ needs.build-streamlit-image.outputs.image_tag }}
+          image: ${{ needs.build-streamlit-image.outputs.first_tag }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       packages: write
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
-      first_tag: ${{ steps.first-tag.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -60,10 +59,6 @@ jobs:
             # PR builds get a unique tag based on PR number and commit
             type=ref,event=pr
 
-      - name: Extract first tag for Docker Scout
-        id: first-tag
-        run: echo "tag=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)" >> $GITHUB_OUTPUT
-
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v5
@@ -75,27 +70,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  docker-scout:
-    needs: build-streamlit-image
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PAT }}
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Docker Scout CVE scan on built image
         uses: docker/scout-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      pull-requests: write
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
 
@@ -72,17 +71,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Log in to Docker Hub for Scout
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PAT }}
-
-      - name: Run Docker Scout CVE scan on built image
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: local://fema-ffrd/stormlit:${{ steps.meta.outputs.version }}
-          only-severities: critical,high
-          summary: true
-          exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ${{ steps.meta.outputs.tags }}
+          image: local://fema-ffrd/stormlit:${{ steps.meta.outputs.version }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,6 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ${{ needs.build-streamlit-image.outputs.first_tag }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       push_to_registry: true
-      platforms: 'linux/amd64,linux/arm64'
+      platforms: 'linux/amd64'
     secrets: inherit
 
   deploy-infrastructure:

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -32,15 +32,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract first image tag
-        id: extract-tag
-        run: echo "tag=$(echo '${{ inputs.image_tag }}' | head -n1)" >> $GITHUB_OUTPUT
-
       - name: Run Docker Scout CVE scan
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ${{ steps.extract-tag.outputs.tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
+          image: ${{ inputs.image_tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -39,3 +39,4 @@ jobs:
           image: ${{ inputs.image_tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
           only-severities: critical,high
           summary: true
+          exit-code: true

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -32,11 +32,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract first image tag
+        id: extract-tag
+        run: echo "tag=$(echo '${{ inputs.image_tag }}' | head -n1)" >> $GITHUB_OUTPUT
+
       - name: Run Docker Scout CVE scan
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ${{ inputs.image_tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
+          image: ${{ steps.extract-tag.outputs.tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,9 +25,18 @@ jobs:
     permissions:
       contents: read
       packages: write
-      pull-requests: write
     uses: ./.github/workflows/build.yml
     with:
-      push_to_registry: false
+      push_to_registry: true
       platforms: 'linux/amd64,linux/arm64'
+    secrets: inherit
+
+  docker-scout:
+    needs: build
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/docker-scout.yml
+    with:
+      image_tag: ${{ needs.build.outputs.image_tag }}
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       push_to_registry: true
-      platforms: 'linux/amd64,linux/arm64'
+      platforms: 'linux/amd64'
     secrets: inherit
 
   docker-scout:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # stormlit
-A streamlit application designed for interacting with probabilistic flood hazards modeling data 
+A streamlit application designed for interacting with probabilistic flood hazards modeling data
+
+[![Deploy](https://github.com/fema-ffrd/stormlit/actions/workflows/deploy.yml/badge.svg)](https://github.com/fema-ffrd/stormlit/actions/workflows/deploy.yml)
+[![Docker Scout](https://github.com/fema-ffrd/stormlit/actions/workflows/docker-scout.yml/badge.svg)](https://github.com/fema-ffrd/stormlit/actions/workflows/docker-scout.yml) 
 
 ## Stormlit Development Environment
 The development container provides a consistent environment for Stormlit development with Python (via Micromamba), Node.js, AWS CLI, CDKTF, PgStac API, and PostgreSQL.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -20,11 +20,10 @@ COPY .streamlit .streamlit
 FROM mambaorg/micromamba:2.3.0
 
 # fix for CVE-2025-6020 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087019
-# fix for CVE-2025-22874 - update Go to 1.24.4+
 USER root
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     apt-get update && \
-    apt-get install -y -t unstable libpam0g libpam-modules libpam-modules-bin libpam-runtime golang-1.24 && \
+    apt-get install -y -t unstable libpam0g libpam-modules libpam-modules-bin libpam-runtime && \
     rm /etc/apt/sources.list.d/unstable.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,6 +19,17 @@ COPY .streamlit .streamlit
 
 FROM mambaorg/micromamba:2.3.0
 
+# fix for CVE-2024-10963 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087019
+USER root
+RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
+    apt-get update && \
+    apt-get install -y -t unstable libpam0g libpam-modules libpam-modules-bin libpam-runtime && \
+    rm /etc/apt/sources.list.d/unstable.list && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER mambauser
+
 COPY --from=builder /opt/conda /opt/conda
 COPY --from=builder /app /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -20,10 +20,11 @@ COPY .streamlit .streamlit
 FROM mambaorg/micromamba:2.3.0
 
 # fix for CVE-2025-6020 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087019
+# fix for CVE-2025-22874 - update Go to 1.24.4+
 USER root
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     apt-get update && \
-    apt-get install -y -t unstable libpam0g libpam-modules libpam-modules-bin libpam-runtime && \
+    apt-get install -y -t unstable libpam0g libpam-modules libpam-modules-bin libpam-runtime golang-1.24 && \
     rm /etc/apt/sources.list.d/unstable.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,7 +19,7 @@ COPY .streamlit .streamlit
 
 FROM mambaorg/micromamba:2.3.0
 
-# fix for CVE-2024-10963 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087019
+# fix for CVE-2025-6020 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087019
 USER root
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     apt-get update && \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,25 +1,49 @@
-FROM mambaorg/micromamba:2.3.0 AS builder
+FROM ubuntu:24.04 AS builder
 
 WORKDIR /app
 
-USER root
+RUN apt-get update && apt-get install -y \
+    curl \
+    tar \
+    bzip2 \
+    build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install build-essential -y \
-    && apt-get clean
+# Install micromamba using the recommended method
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba \
+    && mv bin/micromamba /usr/local/bin/micromamba \
+    && chmod +x /usr/local/bin/micromamba
 
-USER mambauser
+# Set up micromamba environment
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+RUN /usr/local/bin/micromamba shell init -s bash -r /opt/micromamba
 
 COPY env.yml env.yml
-RUN micromamba install -y -n base -f env.yml && \
+RUN eval "$(/usr/local/bin/micromamba shell hook -s posix)" && \
+    micromamba install -y -n base -f env.yml && \
     micromamba clean --all --yes
 
 COPY src src
 COPY src/main.py src/main.py
 COPY .streamlit .streamlit
 
-FROM mambaorg/micromamba:2.3.0
+FROM ubuntu:24.04
 
-COPY --from=builder /opt/conda /opt/conda
+RUN apt-get update && apt-get install -y \
+    curl \
+    tar \
+    bzip2 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install micromamba in final image
+RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba \
+    && mv bin/micromamba /usr/local/bin/micromamba \
+    && chmod +x /usr/local/bin/micromamba
+
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+COPY --from=builder /opt/micromamba /opt/micromamba
 COPY --from=builder /app /app
 
 WORKDIR /app
@@ -30,5 +54,8 @@ EXPOSE 8501
 # Configure Streamlit to run on 0.0.0.0 to be accessible outside container
 ENV STREAMLIT_SERVER_ADDRESS="0.0.0.0"
 
+# Set up shell for micromamba
+RUN /usr/local/bin/micromamba shell init -s bash -r /opt/micromamba
+
 # Command to run your application
-CMD ["streamlit", "run", "src/main.py"]
+CMD ["bash", "-c", "eval \"$(/usr/local/bin/micromamba shell hook -s posix)\" && micromamba activate base && streamlit run src/main.py"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,17 +19,6 @@ COPY .streamlit .streamlit
 
 FROM mambaorg/micromamba:2.3.0
 
-# fix for CVE-2025-6020 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087019
-USER root
-RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
-    apt-get update && \
-    apt-get install -y -t unstable libpam0g libpam-modules libpam-modules-bin libpam-runtime && \
-    rm /etc/apt/sources.list.d/unstable.list && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-USER mambauser
-
 COPY --from=builder /opt/conda /opt/conda
 COPY --from=builder /app /app
 


### PR DESCRIPTION
Updates docker scout workflow to run on images built from the PR instead of "latest". Re-based Dockerfile to Ubuntu 24.04 rather than micromamba/debian base image which has a known unresolved vulnerability. The docker scout action does not play nice with buildx action and local images, so the simplest method is it push it to a the registry before scanning.