### PR TITLE
Add flood-data-plotter service configuration to ECS

### DIFF
--- a/iac/config.py
+++ b/iac/config.py
@@ -75,12 +75,14 @@ class EcsConfig:
         instance_count (int): The number of ECS instances.
         stormlit_config (EcsServiceConfig): Configuration for the Stormlit service.
         stac_api_config (EcsServiceConfig): Configuration for the STAC FastAPI PGSTAC service.
+        flood_data_plotter_config (EcsServiceConfig): Configuration for the Flood Data Plotter service.
     """
 
     instance_type: str
     instance_count: int
     stormlit_config: EcsServiceConfig
     stac_api_config: EcsServiceConfig
+    flood_data_plotter_config: EcsServiceConfig
 
 
 @dataclass
@@ -219,7 +221,7 @@ def get_development_config() -> EnvironmentConfig:
             ),
         ),
         ecs=EcsConfig(
-            instance_type="t3.medium",
+            instance_type="t3.large",
             instance_count=1,
             stormlit_config=EcsServiceConfig(
                 image_repository="ghcr.io/fema-ffrd/stormlit",
@@ -232,6 +234,14 @@ def get_development_config() -> EnvironmentConfig:
             stac_api_config=EcsServiceConfig(
                 image_repository="ghcr.io/stac-utils/stac-fastapi-pgstac",
                 image_tag="4.0.0",
+                container_count=1,
+                cpu=512,
+                memory=1024,
+                container_port=8080,
+            ),
+            flood_data_plotter_config=EcsServiceConfig(
+                image_repository="ghcr.io/fema-ffrd/flood-data-plotter",
+                image_tag="latest",
                 container_count=1,
                 cpu=512,
                 memory=1024,
@@ -293,7 +303,7 @@ def get_production_config() -> EnvironmentConfig:
             ),
         ),
         ecs=EcsConfig(
-            instance_type="t3.medium",
+            instance_type="t3.large",
             instance_count=1,
             stormlit_config=EcsServiceConfig(
                 image_repository="ghcr.io/fema-ffrd/stormlit",
@@ -306,6 +316,14 @@ def get_production_config() -> EnvironmentConfig:
             stac_api_config=EcsServiceConfig(
                 image_repository="ghcr.io/stac-utils/stac-fastapi-pgstac",
                 image_tag="4.0.0",
+                container_count=1,
+                cpu=512,
+                memory=1024,
+                container_port=8080,
+            ),
+            flood_data_plotter_config=EcsServiceConfig(
+                image_repository="ghcr.io/fema-ffrd/flood-data-plotter",
+                image_tag="latest",
                 container_count=1,
                 cpu=512,
                 memory=1024,

--- a/iac/infrastructure/constructs/ecs_services.py
+++ b/iac/infrastructure/constructs/ecs_services.py
@@ -145,6 +145,50 @@ class EcsServicesConstruct(Construct):
                 enable_service_connect=False,
             )
 
+        # Create flood-data-plotter service
+        if "flood-data-plotter" in service_roles:
+            flood_data_plotter_container_definitions = [
+                {
+                    "name": "flood-data-plotter",
+                    "image": f"{ecs_config.flood_data_plotter_config.image_repository}:{ecs_config.flood_data_plotter_config.image_tag}",
+                    "cpu": ecs_config.flood_data_plotter_config.cpu,
+                    "memory": ecs_config.flood_data_plotter_config.memory,
+                    "essential": True,
+                    "portMappings": [
+                        {
+                            "containerPort": ecs_config.flood_data_plotter_config.container_port,
+                            "protocol": "tcp",
+                            "name": "flood-data-plotter-http",
+                        }
+                    ],
+                    "environment": [],
+                    "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": f"/ecs/{self.resource_prefix}-flood-data-plotter",
+                            "awslogs-region": current_region,
+                            "awslogs-stream-prefix": "flood-data-plotter",
+                            "awslogs-create-group": "true",
+                        },
+                    },
+                }
+            ]
+
+            self.services["flood-data-plotter"] = self._create_service(
+                service_name="flood-data-plotter",
+                container_definitions=flood_data_plotter_container_definitions,
+                roles=service_roles["flood-data-plotter"],
+                service_config=ecs_config.flood_data_plotter_config,
+                cluster_id=cluster_id,
+                private_subnet_ids=private_subnet_ids,
+                security_group_id=security_group_id,
+                tags=tags,
+                load_balancers=[],
+                enable_service_connect=True,
+                service_connect_service_name="flood-data-plotter-svc",
+                service_connect_port_name="flood-data-plotter-http",
+            )
+
         # Create STAC API service
         if "stac-api" in service_roles:
             stac_container_definitions = [

--- a/iac/infrastructure/stacks/application_stack.py
+++ b/iac/infrastructure/stacks/application_stack.py
@@ -74,6 +74,10 @@ class ApplicationStack(BaseStack):
                     "execution_role_statements": [],
                     "secret_arns": [pgstac_admin_secret_arn],
                 },
+                "flood-data-plotter": {
+                    "task_role_statements": [],
+                    "execution_role_statements": [],
+                },
             },
             tags=config.tags,
         )
@@ -140,6 +144,14 @@ class ApplicationStack(BaseStack):
                 ),
                 task_role_arn=Token.as_string(
                     self.iam.service_task_roles["stac-api"].arn
+                ),
+            ),
+            "flood-data-plotter": ServiceRoles(
+                execution_role_arn=Token.as_string(
+                    self.iam.service_execution_roles["flood-data-plotter"].arn
+                ),
+                task_role_arn=Token.as_string(
+                    self.iam.service_task_roles["flood-data-plotter"].arn
                 ),
             ),
         }


### PR DESCRIPTION
Requires that the build issue identified in https://github.com/fema-ffrd/flood-data-plotter/pull/1 be resolved and the image pushed to the registry for this deployment to be successful