### PR TITLE
scale down production deployment

### DIFF
--- a/iac/config.py
+++ b/iac/config.py
@@ -281,7 +281,7 @@ def get_production_config() -> EnvironmentConfig:
             dynamodb_table="cdktf-state-lock-fema-ffrd",
         ),
         database=DatabaseConfig(
-            instance_class="db.t4g.medium",
+            instance_class="db.t4g.micro",
             allocated_storage=20,
             max_allocated_storage=100,
             deletion_protection=False,
@@ -304,11 +304,11 @@ def get_production_config() -> EnvironmentConfig:
         ),
         ecs=EcsConfig(
             instance_type="t3.2xlarge",
-            instance_count=1,
+            instance_count=0,
             stormlit_config=EcsServiceConfig(
                 image_repository="ghcr.io/fema-ffrd/stormlit",
                 image_tag=None,
-                container_count=1,
+                container_count=0,
                 cpu=6144,
                 memory=22528,
                 container_port=8501,
@@ -316,7 +316,7 @@ def get_production_config() -> EnvironmentConfig:
             stac_api_config=EcsServiceConfig(
                 image_repository="ghcr.io/stac-utils/stac-fastapi-pgstac",
                 image_tag="4.0.0",
-                container_count=1,
+                container_count=0,
                 cpu=1024,
                 memory=2048,
                 container_port=8080,
@@ -324,7 +324,7 @@ def get_production_config() -> EnvironmentConfig:
             flood_data_plotter_config=EcsServiceConfig(
                 image_repository="ghcr.io/fema-ffrd/flood-data-plotter",
                 image_tag="latest",
-                container_count=1,
+                container_count=0,
                 cpu=512,
                 memory=2048,
                 container_port=8080,


### PR DESCRIPTION
Scales EC2 to 0 and RDS to a micro instance. I also manually shutdown the bastion development instance. This should save roughly $300/month plus the cost of the dev EC2, but we're still paying around $100/month in RDS instance, NAT Gateway, ALB, and API Gateway NLB to make spinning things back up less time consuming